### PR TITLE
added -f to unzip to overwrite local packer extraction

### DIFF
--- a/packer-install.sh
+++ b/packer-install.sh
@@ -205,7 +205,7 @@ if shasum -h 2&> /dev/null; then
 fi
 
 # EXTRACT ZIP
-unzip -qq "$FILENAME" || exit 1
+unzip -f -qq "$FILENAME" || exit 1
 
 if [[ ! "$cwdInstall" ]]; then
   # COPY TO DESTINATION


### PR DESCRIPTION
In my pipeline(s) that I wanted to install the latest version of packer, if a previous run of a pipeline had already downloaded packer into the cwd unzip would fail to overwrite it. I just threw a quick and dirty -f to unzip on there. 