### PR TITLE
accept "latest" as a valid -i parameter value

### DIFF
--- a/packer-install.sh
+++ b/packer-install.sh
@@ -93,7 +93,7 @@ done
 shift $((OPTIND-1))
 
 # POPULATE VARIABLES NEEDED TO CREATE DOWNLOAD URL AND FILENAME
-if [[ -z "$VERSION" ]]; then
+if [[ -z "$VERSION" || "$VERSION" == "latest" ]]; then
   VERSION=$(getLatest)
 fi
 OS=$(uname -s | tr '[:upper:]' '[:lower:]')


### PR DESCRIPTION
Thanks for maintaining this script! it works great!

When running this script in another packer build i ran into an issue. When allowing users to optionally set the packer version...

```
variable "packer_version" {
  type = string
  description = "semver of desired packer version, default is latest"
  default = ""

  validation {
    error_message = "Must be a valid semantic version or \"\" (default)."
    condition     = (
      var.packer_version == "" ||
      can(regex("^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$", var.packer_version))
    )
  }
}

...
  provisioner "shell" {
    execute_command = "chmod +x {{ .Path }}; {{ .Vars }} {{ .Path }} -i ${var.packer_version}"
    script           = "${path.cwd}/scripts/packer-install.sh"
  }
```

packer does not output a literal `""` and the script errored:
```
./packer-install.sh -i   
Error - i requires an argument
usage: packer-install.sh [-i VERSION] [-a] [-c] [-h] [-v]
     -i VERSION : specify version to install in format '' (OPTIONAL)
     -a         : automatically use sudo to install to /usr/local/bin
     -c         : leave binary in working directory (for CI/DevOps use)
     -h         : help
     -v         : display packer-install.sh version
```

Allow setting `"latest"` OR `""` gets around this